### PR TITLE
HACK: enable backtraces in tests to find out what's going wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
   include:
     - env: GAPBRANCH=master
     - env: GAPBRANCH=stable-4.11
-    - env: GAPBRANCH=stable-4.10
-    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=stable-4.10 GAP_PKGS_TO_CLONE="cryst" # for bugfixes
+    - env: GAPBRANCH=stable-4.9  GAP_PKGS_TO_CLONE="cryst" # for bugfixes
 
 branches:
   only:

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -1,5 +1,8 @@
 LoadPackage("hapcryst");
 
+AlwaysPrintTracebackOnError:=true;
+OnBreak := function() Where(6000); end;
+
 TestDirectory(DirectoriesPackageLibrary( "hapcryst", "tst" ),
   rec(exitGAP     := true,
       testOptions := rec(compareFunction := "uptowhitespace") ) );


### PR DESCRIPTION
I've recently update master with 4e38aef24a888eb6457176ee678e49abf30713d1 to fix the Travis CI tests. This fixed the tests against GAP's `stable-4.11`; there are still errors against GAP's `master` branch, due to https://github.com/gap-system/gap/issues/3889, but that'll be resolved elsewhere soon.

But there are different errors when using GAP 4.10 and 4.9, namely a recursion depth trap. So this HACK PR enables error backtraces  to help narrow down the issue.