### PR TITLE
removed SignRat function, called SignInt instead

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,9 +1,15 @@
+0.1.12
+- utility SignRat removed and calls to SignRat changed to SignInt
+
+------------------
+
 0.1.11:
 
 - HAPcryst now calls polymaking with keywords "FACES" and "DIMS" to create
   a resulution of a Bieberbach group. This requires a "next generation"
   version of polymake.
 - One minor change that should reduce the number of calls to polymake by one.
+
 ------------------
 
 0.1.10:

--- a/examples/orbitcoloring.gap
+++ b/examples/orbitcoloring.gap
@@ -203,7 +203,7 @@ fraction2floatString:=function(q,precision)
        then
         return "0";
     fi;
-    sign:=SignRat(q);
+    sign:=SignInt(q);
     if sign=-1
        then
         signString:="-";

--- a/lib/FundamentalDomainStandardSP.gi
+++ b/lib/FundamentalDomainStandardSP.gi
@@ -53,7 +53,7 @@ smallestPointOfOneCubeAroundCenter:=function(center)
     for i in [1..Size(center)]
       do
         entry:=edge[i];
-        sign:=SignRat(entry);
+        sign:=SignInt(entry);
         if sign=0 then sign:=1; fi;
         minusentry:=-sign/2+entry;
         plusentry:=sign/2+entry;

--- a/lib/misc.gd
+++ b/lib/misc.gd
@@ -24,10 +24,6 @@
 ##
 ##############################
 #
-DeclareOperation("SignRat",[IsRat]);
-        
-##############################
-#
 # New operations for matrices. The names say it all
 # 
 DeclareProperty("IsSquareMat",IsMatrix);

--- a/lib/misc.gi
+++ b/lib/misc.gi
@@ -22,24 +22,6 @@
 #Y along with this program; if not, write to the Free Software 
 #Y Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
 ##
-# there seems to be not method for rationals, even though SignInt 
-# did work in all of the cases I tried.
-InstallMethod(SignRat, "for rationals",[IsRat],
-        function(rat)
-    if rat>0
-       then
-        return 1;
-    elif rat<0
-      then
-        return -1;
-    elif rat=0
-      then
-        return 0;
-    else
-        Error("cannot calculate sign of rational");
-    fi;
-    #return SignInt(rat*DenominatorRat(rat));
-end);
   
 
 ##############################

--- a/lib/translations.gi
+++ b/lib/translations.gi
@@ -1,6 +1,6 @@
 #############################################################################
 ##
-#W translations.gi 			 HAPcryst package		 Marc Roeder
+#W translations.gi 		HAPcryst package		 Marc Roeder
 ##
 ##  
 
@@ -89,7 +89,7 @@ InstallMethod(ShiftedOrbitPart,
             returnpoint[i]:=x[i]-Int(x[i]);
             if AbsoluteValue(returnpoint[i])>1/2
                then
-                returnpoint[i]:=returnpoint[i]+SignRat(returnpoint[i]);
+                returnpoint[i]:=returnpoint[i]+SignInt(returnpoint[i]);
             elif returnpoint[i]=-1/2 
               then
                 returnpoint[i]:=1/2;
@@ -121,10 +121,10 @@ InstallMethod(TranslationsToOneCubeAroundCenter,[IsVector,IsVector],
         abs:=AbsoluteValue(difference[entry]);
         if abs=1/2
            then
-            difference[entry]:=[0,SignRat(difference[entry])];
+            difference[entry]:=[0,SignInt(difference[entry])];
         elif abs>1/2
           then
-            difference[entry]:=[SignRat(difference[entry])];
+            difference[entry]:=[SignInt(difference[entry])];
         else
             difference[entry]:=[0];
         fi;


### PR DESCRIPTION
This PR is part of the process of dealing with GAP issue #5191. 
Now that SignRat has been replaced by SignInt in HAP, we can remove the declaration and method for SignRat in HAPcryst, and replace calls to SignRat by SignInt.  Once this PR is merged we can proceed to work on a Sign function for the main GAP library, and maybe reintroduce a SignRat function there. 
Once again I am getting a host of errors when running HAPcryst.tst on my system, so I shall be interested to see what happens when this PR proposal is tested. 