### PR TITLE
Fix DimensionSquareMat

### DIFF
--- a/doc/misc.xml
+++ b/doc/misc.xml
@@ -51,7 +51,7 @@ true
 gap> DimensionSquareMat(m);
 3
 gap> DimensionSquareMat([[1,2],[1,2,3]]);
-Error, Matrix is not square called from
+fail
 </Example>
 
 Affine mappings of <M>n</M> dimensional space are often written as a

--- a/lib/misc.gi
+++ b/lib/misc.gi
@@ -46,7 +46,7 @@ end);
 
 InstallMethod(IsSquareMat,"for matrices",[IsMatrix],
         function(mat)
-        return NrRows(mat) = NrCols(mat);
+        return IsRectangularTable(mat) and NrRows(mat) = NrCols(mat);
 end);
 
 
@@ -55,8 +55,8 @@ end);
 
 InstallMethod(DimensionSquareMat,"for matrices",[IsMatrix],
         function(mat)
-    if NrRows(mat) <> NrCols(mat) then
-        Error("Matrix is not square");
+    if not IsSquareMat(mat) then
+        return fail;
     fi;
     return NrRows(mat);
 end);

--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -9,6 +9,16 @@ gap> IsSquareMat([[1, 2]]);
 false
 
 #
+# DimensionSquareMat
+#
+gap> DimensionSquareMat([[1,2,3],[1,2,3],[1,2,3]]);
+3
+gap> DimensionSquareMat([[1,2,3],[1,2,3]]);
+fail
+gap> DimensionSquareMat([[1,2],[1,2,3]]);
+fail
+
+#
 # Let TranslationsToBox return a list again, instead of an iterator.
 # See <https://github.com/gap-packages/hapcryst/issues/15>
 #


### PR DESCRIPTION
Make sure it adhers to its own documentation and returns fail for
non-square matrices, instead of raising an error. Also catch
malformed matrices. Ensure manual example is correct.
