### PR TITLE
Update Carat to CaratInterface in PackageInfo.g

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -62,7 +62,7 @@ Dependencies := rec(
                    ["polymaking",">=0.8.6"],
                    ],
   SuggestedOtherPackages := [
-                   [ "Carat", ">=1.1" ],
+                   ["CaratInterface",">=2.3.1"],
                    ["CrystCat",">=1.1.2"],
                    ["GAPDoc", ">= 0.99"]
                    ],


### PR DESCRIPTION
The `carat` package was renamed to `CaratInterface` since version 2.3.1. It still loads fine as a suggested package due to it being the only package whose name starts with "carat", but it's probably better not to rely on that. Some of the CI tools also don't have this autocompletion and thus don't recognise `CaratInterface` as a suggested package of `HAPCryst`.